### PR TITLE
version(3.8.2) - Fix the Block API Version

### DIFF
--- a/includes/Shortcode.php
+++ b/includes/Shortcode.php
@@ -453,6 +453,7 @@ class Shortcode {
         foreach ($aSettings as $task => $settings) {
             // register block
             register_block_type($settings['block']['blocktype'], array(
+                'api_version' => 3,
                 'editor_script' => $editorScript,
                 'render_callback' => [$this, 'shortcodeOutput'],
                 'attributes' => $this->getBlockAttributes($settings),

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Plugin Name: rrze-univis ===
-Version: 3.8.1
+Version: 3.8.2
 Plugin URI: https://github.com/RRZE-Webteam/rrze-univis
 GitHub Issue URL: https://github.com/RRZE-Webteam/rrze-univis/issues
 Author: RRZE-Webteam <webmaster@fau.de>

--- a/rrze-univis.php
+++ b/rrze-univis.php
@@ -4,7 +4,7 @@
  * Plugin Name:     RRZE UnivIS
  * Plugin URI:      https://github.com/RRZE-Webteam/rrze-univis
  * Description:     Einbindung von Daten aus UnivIS
- * Version:         3.8.1
+ * Version:         3.8.2
  * Requires at least: 6.9.4
  * Requires PHP:      8.3
  * Author:          RRZE-Webteam


### PR DESCRIPTION
Bumps the Block API Version to 3 to prevent issues within the BlockEditor with previous WP Versions starting at 6.9.4
